### PR TITLE
feat: add ability to load ts over network

### DIFF
--- a/examples/example_import_ts.ts
+++ b/examples/example_import_ts.ts
@@ -1,0 +1,16 @@
+import { plus } from "https://deno.land/x/math@v1.1.0/mod.ts";
+import Thread from "../Thread.ts";
+
+const tr = new Thread(
+  (e) => {
+    return plus(e.data as number, 1);
+  },
+  "module",
+  ['import { plus } from "https://deno.land/x/math@v1.1.0/mod.ts"'],
+);
+
+tr.postMessage(1);
+
+tr.onMessage((e) => {
+  console.log(e);
+});


### PR DESCRIPTION
Regarding import functionlity I wonder why you disable importing TS. This PR will enable importin ts file over network like example below

```ts
import { plus } from "https://deno.land/x/math@v1.1.0/mod.ts";
import Thread from "../Thread.ts";

const tr = new Thread(
  (e) => {
    return plus(e.data as number, 1);
  },
  "module",
  ['import { plus } from "https://deno.land/x/math@v1.1.0/mod.ts"'],
);

tr.postMessage(1);

tr.onMessage((e) => {
  console.log(e);
});
```

Please review my implementation